### PR TITLE
Support Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "hammerstone/sidecar": "^0.6",
+        "hammerstone/sidecar": "^0.7",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "spatie/laravel-package-tools": "^1.14.0",
         "spatie/mjml-php": "^1.0"


### PR DESCRIPTION
Support Laravel 12 by bumping `hammerstone/sidecar` requirement. The caret constraint behaves differently in composer for pre 1.0 versions.